### PR TITLE
snap: Avoid using wayland QPA

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,7 @@ confinement: strict
 
 apps:
   rpi-imager:
-    command: bin/desktop-launch rpi-imager
+    command: bin/desktop-launch rpi-imager -platform xcb
     plugs:
       - x11
       - opengl


### PR DESCRIPTION
The Wayland Qt5 QPA plugin is missing from the snap.
It has theming issues anyways due to CSD, so make sure
to connect to Xwayland on a Wayland enabled system instead.